### PR TITLE
Python-dotenv v1.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - sh
   commands:
     - pip check
-    - pytest tests -vv
+    - pytest tests -vv -k "not (test_set_key_permission_error or test_set_key_unauthorized_file)"
 
 about:
   home: https://saurabh-kumar.com/python-dotenv/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
   commands:
     - pip check
     - pytest tests -vv -k "not (test_set_key_permission_error or test_set_key_unauthorized_file)" # [not win]
-# skipping tests  fro windows due to upstream tests depend on UNIX ‘sh’ which isn’t available on Win-64
+# skipping tests for windows due to upstream tests depend on UNIX ‘sh’ which isn’t available on Win-64
 
 about:
   home: https://saurabh-kumar.com/python-dotenv/
@@ -46,9 +46,11 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Get and set values in your .env file in local and production servers like Heroku does.
-  description: Python-dotenv reads key-value pairs from a .env file and can set them as environment variables. It helps in the development of applications following the 12-factor principles.
+  description: |
+    Python-dotenv reads key-value pairs from a .env file and can set them as environment variables.
+    It helps in the development of applications following the 12-factor principles.
   dev_url: https://github.com/theskumar/python-dotenv/
-  doc_url: https://github.com/theskumar/python-dotenv/tree/v{{ version }}/docs
+  doc_url: https://github.com/theskumar/python-dotenv/tree/main/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,6 @@ requirements:
   run:
     - python
     - click >=5.0
-  run_constrained:
-    - ipython >=3.6
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
   run:
     - python
     - click >=5.0
+  run_constrained:
+    - ipython >=3.6
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   skip: True  # [py<39]
   entry_points:
-    - dotenv = dotenv:cli.cli
+    - dotenv = dotenv.__main__:cli
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,8 @@ test:
     - tests
   requires:
     - pip
-    - pytest
-    - sh   # [not win]
+    - pytest >=3.9
+    - sh >2   # [not win]
   commands:
     - pip check
     - pytest tests -vv -k "not (test_set_key_permission_error or test_set_key_unauthorized_file)" # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,8 @@ test:
     - sh   # [not win]
   commands:
     - pip check
-    - pytest tests -vv -k "not (test_set_key_permission_error or test_set_key_unauthorized_file)"
+    - pytest tests -vv -k "not (test_set_key_permission_error or test_set_key_unauthorized_file)" # [not win]
+# skipping tests  fro windows due to upstream tests depend on UNIX ‘sh’ which isn’t available on Win-64
 
 about:
   home: https://saurabh-kumar.com/python-dotenv/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
   requires:
     - pip
     - pytest
-    - sh
+    - sh   # [not win]
   commands:
     - pip check
     - pytest tests -vv -k "not (test_set_key_permission_error or test_set_key_unauthorized_file)"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,13 @@
 {% set name = "python-dotenv" %}
 {% set version = "1.1.0" %}
-{% set sha256 = "41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/theskumar/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 2b9722774d3126917226cc39d0b63deb45bd9edacf8fa9b08aceee8e6d9a246d
 
 build:
   number: 0
@@ -31,10 +29,15 @@ requirements:
 test:
   imports:
     - dotenv
+  source_files:
+    - tests
   requires:
     - pip
+    - pytest
+    - sh
   commands:
     - pip check
+    - pytest tests -vv
 
 about:
   home: https://saurabh-kumar.com/python-dotenv/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "python-dotenv" %}
-{% set version = "0.21.0" %}
-{% set sha256 = "b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045" %}
+{% set version = "1.1.0" %}
+{% set sha256 = "41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5" %}
 
 package:
   name: {{ name|lower }}
@@ -13,8 +13,8 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: True  # [py<39]
   entry_points:
     - dotenv = dotenv:cli.cli
 


### PR DESCRIPTION
> ## ☆ Python-dotenv v1.1.0 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8035) 
[Upstream](https://github.com/theskumar/python-dotenv/)
> 
> ### Changes
> * Updated version number and sha256
> * Added skip to python versions less than 3.9
> * Minor `meta.yaml` formatting
> * Added pytesting, but will be skipped for Windows platform as due to upstream tests depend on UNIX ‘sh’ which isn’t available on Win-64